### PR TITLE
chore: use codenotary account for docker-compose image retrieval

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   immudb:
-    image: "ameingast/immudb"
+    image: "codenotary/immudb"
     container_name: "immudb"
     restart: "on-failure"
     ports:
@@ -15,7 +15,7 @@ services:
       - "immudb:/immudb"
   ctrlt:
     build: "."
-    image: "ameingast/ctrlt"
+    image: "codenotary/ctrlt"
     container_name: "ctrlt"
     restart: "on-failure"
     depends_on:


### PR DESCRIPTION
Switch over to the official codenotary docker-hub account for codenotary images.